### PR TITLE
Environmental changes and php fix

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,7 @@
 #Specific project name
-COMPOSE_PROJECT_NAME="NHL_Stenden_PHP"
+COMPOSE_PROJECT_NAME="NHL_Stenden"
 
 # Environment Variables for database.
 DB_SERVER="mysql"
 DB_ROOT_USER="root"
 DB_ROOT_PASSWORD="qwerty"
-
-#DB_USER: 'root'
-#DB_PASSWORD: 'secret'

--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+#Specific project name
+COMPOSE_PROJECT_NAME="NHL_Stenden_PHP"
+
+# Environment Variables for database.
+DB_SERVER="mysql"
+DB_USER="root"
+DB_PASSWORD="qwerty"

--- a/.env
+++ b/.env
@@ -3,5 +3,8 @@ COMPOSE_PROJECT_NAME="NHL_Stenden_PHP"
 
 # Environment Variables for database.
 DB_SERVER="mysql"
-DB_USER="root"
-DB_PASSWORD="qwerty"
+DB_ROOT_USER="root"
+DB_ROOT_PASSWORD="qwerty"
+
+#DB_USER: 'root'
+#DB_PASSWORD: 'secret'

--- a/PHP.dockerfile
+++ b/PHP.dockerfile
@@ -5,3 +5,5 @@ RUN docker-php-ext-install mysqli
 
 #Nicer errors
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+EXPOSE 9000

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -31,7 +31,7 @@
                 <p>The database is accessable via PHPMyAdmin or by using another tool like MySQL Workbench. The database
                     can be found at <a href="http://127.0.0.1:3306">127.0.0.1:3306</a>. The default username is <strong>"root"</strong>
                     with password <strong>"qwerty"</strong>. Keep in mind, this is a root user with all permissions. To add another
-                    user, go to the docker-compose file and uncomment the two MYSQL_ lines and fill in the desired user. Afterwards, use <i>docker-compose up</i> to reinitiate the environment.
+                    user, go to the .env file and uncomment the two DB_ lines and fill in the desired user. Afterwards, use <i>docker-compose up</i> to reinitiate the environment.
                 </p>
                 <p>Happy coding! 🐱‍👤</p>
             </div>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,9 @@ services:
             context: .
             dockerfile: PHP.dockerfile
         environment:
-            - DB_SERVER: ${DB_SERVER}
-            - DB_USER: ${DB_ROOT_USER}
-            - DB_PASSWORD: ${DB_ROOT_PASSWORD}
+            - DB_SERVER=${DB_SERVER}
+            - DB_USER=${DB_ROOT_USER}
+            - DB_PASSWORD=${DB_ROOT_PASSWORD}
         volumes:
             - ./app:/app
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
         ports:
             - "80:80"
         volumes:
-            - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
+            - ./nginx.conf:/etc/nginx/conf.d/app.conf
             - ./app:/app
     php:
         image: php:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,9 @@ services:
             context: .
             dockerfile: PHP.dockerfile
         environment:
-            - DB_SERVER=${DB_SERVER}
-            - DB_USER=${DB_ROOT_USER}
-            - DB_PASSWORD=${DB_ROOT_PASSWORD}
+            - DB_SERVER: ${DB_SERVER}
+            - DB_USER: ${DB_ROOT_USER}
+            - DB_PASSWORD: ${DB_ROOT_PASSWORD}
         volumes:
             - ./app:/app
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,14 +3,14 @@ services:
     web:
         image: nginx:latest
         environment:
-          - DB_USER=${DB_SERVER}
-          - DB_USER=${DB_USER}
-          - DB_USER=${DB_PASSWORD}
+            - DB_USER=${DB_SERVER}
+            - DB_USER=${DB_ROOT_USER}
+            - DB_USER=${DB_ROOT_PASSWORD}
         ports:
             - "80:80"
         volumes:
-        - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
-        - ./app:/app
+            - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
+            - ./app:/app
     php:
         build:
             context: .
@@ -20,9 +20,9 @@ services:
     mysql:
         image: mariadb:latest
         environment:
-            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-            #MYSQL_USER: 'root'
-            #MYSQL_PASSWORD: 'secret'
+            MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+            MYSQL_USER: ${DB_USER}
+            MYSQL_PASSWORD: ${DB_PASSWORD}
         volumes:
             - mysqldata:/var/lib/mysql
         ports:
@@ -31,7 +31,7 @@ services:
         image: phpmyadmin
         restart: always
         ports:
-        - 8080:80
+            - 8080:80
         environment:
             PMA_HOST: mysql
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,10 @@ version: '3'
 services:
     web:
         image: nginx:latest
+        environment:
+          - DB_USER=${DB_SERVER}
+          - DB_USER=${DB_USER}
+          - DB_USER=${DB_PASSWORD}
         ports:
             - "80:80"
         volumes:
@@ -16,7 +20,7 @@ services:
     mysql:
         image: mariadb:latest
         environment:
-            MYSQL_ROOT_PASSWORD: 'qwerty'
+            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
             #MYSQL_USER: 'root'
             #MYSQL_PASSWORD: 'secret'
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,6 @@ version: '3'
 services:
     web:
         image: nginx:latest
-        environment:
-            - DB_USER=${DB_SERVER}
-            - DB_USER=${DB_ROOT_USER}
-            - DB_USER=${DB_ROOT_PASSWORD}
         build:
             context: .
             dockerfile: nginx.dockerfile
@@ -15,9 +11,14 @@ services:
             - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
             - ./app:/app
     php:
+        image: php:latest
         build:
             context: .
             dockerfile: PHP.dockerfile
+        environment:
+            - DB_SERVER=${DB_SERVER}
+            - DB_USER=${DB_ROOT_USER}
+            - DB_PASSWORD=${DB_ROOT_PASSWORD}
         volumes:
             - ./app:/app
         depends_on:
@@ -26,8 +27,6 @@ services:
         image: mariadb:latest
         environment:
             MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
-            MYSQL_USER: ${DB_USER}
-            MYSQL_PASSWORD: ${DB_PASSWORD}
         volumes:
             - mysqldata:/var/lib/mysql
         ports:

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,13 +4,13 @@ server {
     root /app/public;
     index index.php index.html index.htm;
     autoindex on;
-    
-    location ~ /.php$ {
+
+    location ~ \.php$ {
         try_files $uri = 404;
         fastcgi_split_path_info ^(.+\.php)(\.+)$;
         fastcgi_index index.php;
         include fastcgi_params;
-        fastcgi_pass localhost:9000;
+        fastcgi_pass php:9000;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
@@ -20,4 +20,4 @@ server {
     try_files $uri $uri/ index.php?$query_string;
   }
 
-} 
+}

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,3 +1,4 @@
-FROM nginx:alpine
+FROM nginx:latest
 
 COPY ./nginx.conf /etc/nginx/conf.d/app.conf
+COPY . /app/

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:fpm
+FROM nginx:alpine
 
 COPY ./nginx.conf /etc/nginx/conf.d/app.conf

--- a/readme.md
+++ b/readme.md
@@ -1,36 +1,52 @@
 # PHP Docker environment for NHL-Stenden students
+
 This project contains a docker-compose file and configuration files for setting up a development environment for the course PHP on NHL-Stenden university of applied sciences.
 
 ## Getting Started
+
 These instructions will aid you in setting up a development environment for use within the PHP courses at NHL-Stenden by using docker. This code is for educational purposes only.
 
 ### Prerequisites
+
 #### Windows
-- [Docker desktop](https://docs.docker.com/desktop/windows/install/) 
+
+- [Docker desktop](https://docs.docker.com/desktop/windows/install/)
 
 #### Mac
+
 - [Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/)
-    - Note: Do check the architecture of your Mac! (x64/arm64)  
+  - Note: Do check the architecture of your Mac! (x64/arm64)
+
 #### Linux and friends
+
 - [Docker engine](https://docs.docker.com/engine/install/#server)
-    - Select your distribution from the table and follow the provided instructions.
+  - Select your distribution from the table and follow the provided instructions.
 
 ### Running
+
 The following steps will set-up your development environment
+
 1. Download the archive containing the necessary files.
 2. Extract the files to a folder in which you will start your project.
 3. Open a terminal in the folder in which you extracted the files.
-    - This can be done within a supporting editor (E.g. Visual studio code)
-    - Alternatively you can use the terminal to navigate or use a file explorer to open a terminal in the desired folder (Windows: ```Shift + right click in explorer -> Powershell```)
+   - This can be done within a supporting editor (E.g. Visual studio code)
+   - Alternatively you can use the terminal to navigate or use a file explorer to open a terminal in the desired folder (Windows: `Shift + right click in explorer -> Powershell`)
 4. Execute the following docker-compose command
 
-```docker-compose up```
+`docker-compose up`
 
 5. Wait for docker to start up the container.
 6. Go to [127.0.0.1](http://127.0.0.1) in your favorite browser, you should see the welcome screen.
 
-
-
 ## Using the environment
-The extracted files contains a folder called "app". Inside this folder there is another folder called "public". The public folder is where you will need to place your own code and files that are publicly available to the outside world. Everything else is private. 
 
+The extracted files contains a folder called "app". Inside this folder there is another folder called "public". The public folder is where you will need to place your own code and files that are publicly available to the outside world. Everything else is private.
+
+## Database
+
+Database type - Mariadb
+
+The database user and password can be found in ".env". The database can be accessed by connecting to [127.0.0.1:3306] with you favorite database
+
+to get acces too the environmental variables in PHP you can use
+`$_PHP["example"]` change example with the name of the variable.

--- a/readme.md
+++ b/readme.md
@@ -42,11 +42,9 @@ The following steps will set-up your development environment
 
 The extracted files contains a folder called "app". Inside this folder there is another folder called "public". The public folder is where you will need to place your own code and files that are publicly available to the outside world. Everything else is private.
 
-## Database
+## Database - Mariadb
 
-Database type - Mariadb
-
-The database user and password can be found in ".env". The database can be accessed by connecting to [127.0.0.1:3306] with you favorite database
+The database user and password can be found in ".env". The database can be accessed by connecting to `[127.0.0.1:3306]` with you favorite database tool.
 
 to get acces too the environmental variables in PHP you can use
 `$_PHP["example"]` change example with the name of the variable.

--- a/readme.md
+++ b/readme.md
@@ -47,4 +47,4 @@ The extracted files contains a folder called "app". Inside this folder there is 
 The database user and password can be found in ".env". The database can be accessed by connecting to `[127.0.0.1:3306]` with you favorite database tool.
 
 to get acces too the environmental variables in PHP you can use
-`$_PHP["example"]` change example with the name of the variable.
+`$_ENV["example"]` change example with the name of the variable.


### PR DESCRIPTION
### Changelist
.Env file toegevoegd deze environment variables worden ook gebruikt in docker-compose.
Eén van deze variables is `COMPOSE_PROJECT_NAME `  
Deze variable is om het project een naam te geven om hem beter te indexen in docker.

kleine verandering in readme.md en index.php.

### Fixes
PHP file werden eerst gedownload, nu niet meer.
In de PHP.Dockerfile heb ik een `EXPOSE 9000` zodat php nu vanaf een andere container benadert kan worden.
in de nginx.conf heb ik wat dingen aangepast die er voor zorgden dat .php files niet werden gezien door nginx.

Er was een probleem met de nginx:fpm tag. deze heb ik veranderd naar nginx:latest dit zou eigenlijk ook gewoon
een alpine versie kunnen worden later.


### Tests
alles is getest vanaf een windows machine en mac.
heb index.html veranderd naar index.php om te kijken of die het daadwerkelijk deed.
ook heb ik php files gemaakt in de app folder en die geprobeerd te includen en dit werkte ook.


### Additional info
toen ik bezig was met de database environment variables, liep ik tegen het probleem aan dat
`MYSQL_USER, MYSQL_PASSWORD` niet meer gezet kunnen worden als de database eenmaal bestaat.
ik weet niet of dit de bedoeling is of dat er verwacht wordt dat studenten dit op hun eerst compose up
aanpassen. de optie lijkt op dit moment een beetje overbodig.



